### PR TITLE
fix: useDaimoPayStatus()

### DIFF
--- a/packages/connectkit/package.json
+++ b/packages/connectkit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@daimo/pay",
   "private": false,
-  "version": "0.3.8",
+  "version": "0.3.9",
   "author": "Daimo",
   "homepage": "https://pay.daimo.com",
   "license": "BSD-2-Clause license",

--- a/packages/connectkit/src/components/Pages/Confirmation/index.tsx
+++ b/packages/connectkit/src/components/Pages/Confirmation/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { useContext } from "../../DaimoPay";
 
 import { ModalContent, ModalH1, PageContent } from "../../Common/Modal/styles";
@@ -16,14 +16,7 @@ import PoweredByFooter from "../../Common/PoweredByFooter";
 
 const Confirmation: React.FC = () => {
   const { paymentInfo } = useContext();
-  const { daimoPayOrder, refreshOrder } = paymentInfo;
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      refreshOrder();
-    }, 300);
-    return () => clearInterval(interval);
-  }, [refreshOrder]);
+  const { daimoPayOrder } = paymentInfo;
 
   const { done, txURL } = (() => {
     if (daimoPayOrder && daimoPayOrder.mode === DaimoPayOrderMode.HYDRATED) {

--- a/packages/connectkit/src/utils/getPaymentInfo.tsx
+++ b/packages/connectkit/src/utils/getPaymentInfo.tsx
@@ -46,17 +46,23 @@ export interface PaymentInfo {
   onSuccess: (args: { txHash: string; txURL?: string }) => void;
 }
 
-export function getPaymentInfo(
-  setOpen: (showModal: boolean) => void,
-  log: (...args: any[]) => void,
-) {
+export function getPaymentInfo({
+  daimoPayOrder,
+  setDaimoPayOrder,
+  setOpen,
+  log,
+}: {
+  daimoPayOrder: DaimoPayOrder | undefined;
+  setDaimoPayOrder: (o: DaimoPayOrder) => void;
+  setOpen: (showModal: boolean) => void;
+  log: (...args: any[]) => void;
+}) {
   // Wallet state.
   const { address: senderAddr } = useAccount();
   const { writeContractAsync } = useWriteContract();
   const { sendTransactionAsync } = useSendTransaction();
 
   // Daimo Pay order state.
-  const [daimoPayOrder, setDaimoPayOrder] = useState<DaimoPayOrder>();
   const [paymentWaitingMessage, setPaymentWaitingMessage] = useState<string>();
 
   // Payment UI config.


### PR DESCRIPTION
## Summary

Before, polling payment status happened in `useEffect` inside the modal UI.

However, the modal shows the success screen as soon as we get to `dest_status = fast_finish_started`. If the modal is closed (automatically via closeOnSuccess or manually), then we stop polling.

This means the `useDaimoPayStatus()` is stuck on `payment_started`.

### Proposed fix

- Moved polling to the provider
- Poll until intentStatus resolves (to completed or bounced)
- Also, new polling has 300ms delay instead of a 300ms interval = ~same on fast internet, should behave better on slow internet / avoid stacking requests.