### PR TITLE
pass in API URL

### DIFF
--- a/packages/connectkit/package.json
+++ b/packages/connectkit/package.json
@@ -10,9 +10,9 @@
   "type": "module",
   "exports": {
     "import": "./build/index.es.js",
-    "types": "./build/packages/paykit/packages/connectkit/src/index.d.ts"
+    "types": "./build/index.d.ts"
   },
-  "types": "./build/packages/paykit/packages/connectkit/src/index.d.ts",
+  "types": "./build/index.d.ts",
   "engines": {
     "node": ">=12.4"
   },
@@ -23,7 +23,7 @@
   "scripts": {
     "start": "rollup --config rollup.config.dev.js -w",
     "dev": "rollup --config rollup.config.dev.js -w",
-    "build": "rollup --config rollup.config.prod.js",
+    "build": "rollup --config rollup.config.prod.js && rm -rf build/packages",
     "lint": "eslint --max-warnings=0"
   },
   "keywords": [
@@ -73,7 +73,8 @@
     "@types/react": "^18.2.47",
     "@types/react-dom": "^18.2.18",
     "@types/styled-components": "^5.1.25",
-    "rollup": "^2.67.1",
+    "rollup": "^3.29.5",
+    "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-typescript2": "^0.34.0",
     "rollup-plugin-visualizer": "^5.5.4",

--- a/packages/connectkit/package.json
+++ b/packages/connectkit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@daimo/pay",
   "private": false,
-  "version": "0.3.17",
+  "version": "0.3.18",
   "author": "Daimo",
   "homepage": "https://pay.daimo.com",
   "license": "BSD-2-Clause license",

--- a/packages/connectkit/rollup.config.dev.js
+++ b/packages/connectkit/rollup.config.dev.js
@@ -1,14 +1,17 @@
-import json from '@rollup/plugin-json';
+import json from "@rollup/plugin-json";
+import dts from "rollup-plugin-dts";
 import peerDepsExternal from "rollup-plugin-peer-deps-external";
 import typescript from "rollup-plugin-typescript2";
-import createStyledComponentsTransformer from "typescript-plugin-styled-components";
-import packageJson from "./package.json";
+// import createTransformer from "typescript-plugin-styled-components";
 
-const styledComponentsTransformer = createStyledComponentsTransformer({
-  displayName: true,
-});
+import packageJson from "./package.json" with { type: "json" };
+
+// const styledComponentsTransformer = createTransformer({
+//   displayName: true,
+// });
 
 export default [
+  // Build bundle: index.js
   {
     input: ["./src/index.ts"],
     external: ["react", "react-dom", "framer-motion", "wagmi"],
@@ -25,11 +28,25 @@ export default [
       typescript({
         useTsconfigDeclarationDir: true,
         exclude: "node_modules/**",
-        transformers: [
-          () => ({
-            before: [styledComponentsTransformer],
-          }),
-        ],
+        // transformers: [
+        //   () => ({
+        //     before: [styledComponentsTransformer],
+        //   }),
+        // ],
+      }),
+    ],
+  },
+  // Build types: index.d.ts
+  {
+    input: "./build/packages/paykit/packages/connectkit/src/index.d.ts",
+    output: { file: "build/index.d.ts", format: "esm" },
+    plugins: [
+      dts({
+        exclude: ["**/pay-api/**"],
+        compilerOptions: {
+          importsNotUsedAsValues: "remove",
+          preserveValueImports: false,
+        },
       }),
     ],
   },

--- a/packages/connectkit/rollup.config.prod.js
+++ b/packages/connectkit/rollup.config.prod.js
@@ -1,10 +1,12 @@
-import json from '@rollup/plugin-json';
+import json from "@rollup/plugin-json";
+import dts from "rollup-plugin-dts";
 import peerDepsExternal from "rollup-plugin-peer-deps-external";
 import typescript from "rollup-plugin-typescript2";
 
-import packageJson from "./package.json";
+import packageJson from "./package.json" with { type: "json" };
 
 export default [
+  // Build bundle: index.js
   {
     input: ["./src/index.ts"],
     external: ["react", "react-dom", "framer-motion", "wagmi"],
@@ -18,7 +20,21 @@ export default [
       json(),
       typescript({
         useTsconfigDeclarationDir: true,
-        exclude: "node_modules/**",
+        exclude: ["node_modules/**"],
+      }),
+    ],
+  },
+  // Build types: index.d.ts
+  {
+    input: "./build/packages/paykit/packages/connectkit/src/index.d.ts",
+    output: { file: "build/index.d.ts", format: "esm" },
+    plugins: [
+      dts({
+        exclude: ["**/pay-api/**"],
+        compilerOptions: {
+          importsNotUsedAsValues: "remove",
+          preserveValueImports: false,
+        },
       }),
     ],
   },

--- a/packages/connectkit/src/components/Common/Avatar/index.tsx
+++ b/packages/connectkit/src/components/Common/Avatar/index.tsx
@@ -7,7 +7,7 @@ import { useEnsAddress, useEnsAvatar, useEnsName } from "wagmi";
 import { useEnsFallbackConfig } from "../../../hooks/useEnsFallbackConfig";
 import useIsMounted from "../../../hooks/useIsMounted";
 import { ResetContainer } from "../../../styles";
-import { useContext } from "../../DaimoPay";
+import { usePayContext } from "../../DaimoPay";
 
 type Hash = `0x${string}`;
 
@@ -26,7 +26,7 @@ const Avatar: React.FC<{
   radius?: number;
 }> = ({ address, name, size = 96, radius = 96 }) => {
   const isMounted = useIsMounted();
-  const context = useContext();
+  const context = usePayContext();
 
   const imageRef = useRef<any>(null);
   const [loaded, setLoaded] = useState(true);

--- a/packages/connectkit/src/components/Common/ChainSelect/index.tsx
+++ b/packages/connectkit/src/components/Common/ChainSelect/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { ROUTES, useContext } from "../../DaimoPay";
+import { ROUTES, usePayContext } from "../../DaimoPay";
 
 import { flattenChildren, isMobile } from "./../../../utils";
 
@@ -134,7 +134,7 @@ const ChevronDown = ({ ...props }) => (
 );
 
 const ChainSelector: React.FC = () => {
-  const context = useContext();
+  const context = usePayContext();
   const [isOpen, setIsOpen] = useState(false);
   const { chain } = useAccount();
   const { chains } = useSwitchChain();

--- a/packages/connectkit/src/components/Common/ChainSelectDropdown/index.tsx
+++ b/packages/connectkit/src/components/Common/ChainSelectDropdown/index.tsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { useContext } from "../../DaimoPay";
+import { usePayContext } from "../../DaimoPay";
 
 import useMeasure from "react-use-measure";
 
@@ -33,7 +33,7 @@ const ChainSelectDropdown: React.FC<{
   offsetX?: number;
   offsetY?: number;
 }> = ({ children, open, onClose, offsetX = 0, offsetY = 8 }) => {
-  const context = useContext();
+  const context = usePayContext();
   const themeContext = useThemeContext();
 
   const locales = useLocales();

--- a/packages/connectkit/src/components/Common/ChainSelectList/index.tsx
+++ b/packages/connectkit/src/components/Common/ChainSelectList/index.tsx
@@ -20,7 +20,7 @@ import { isCoinbaseWalletConnector, isMobile } from "../../../utils";
 
 import ChainIcons from "../../../assets/chains";
 import useLocales from "../../../hooks/useLocales";
-import { useContext } from "../../DaimoPay";
+import { usePayContext } from "../../DaimoPay";
 
 const Spinner = (
   <svg
@@ -77,7 +77,7 @@ const ChainSelectList = ({
     }
   };
 
-  const { triggerResize } = useContext();
+  const { triggerResize } = usePayContext();
 
   return (
     <SwitchNetworksContainer

--- a/packages/connectkit/src/components/Common/ConnectorList/index.tsx
+++ b/packages/connectkit/src/components/Common/ConnectorList/index.tsx
@@ -1,4 +1,4 @@
-import { ROUTES, useContext } from "../../DaimoPay";
+import { ROUTES, usePayContext } from "../../DaimoPay";
 
 import {
   ConnectorButton,
@@ -24,7 +24,7 @@ import {
 import { WalletProps, useWallets } from "../../../wallets/useWallets";
 
 const ConnectorList = () => {
-  const context = useContext();
+  const context = usePayContext();
   const isMobile = useIsMobile();
 
   const wallets = useWallets();
@@ -81,7 +81,7 @@ const ConnectorItem = ({
   } = useWeb3();
   const uri = getUri();
   const isMobile = useIsMobile();
-  const context = useContext();
+  const context = usePayContext();
 
   const { connect } = useConnect();
 

--- a/packages/connectkit/src/components/Common/Modal/index.tsx
+++ b/packages/connectkit/src/components/Common/Modal/index.tsx
@@ -31,7 +31,7 @@ import {
 } from "./styles";
 
 import useLockBodyScroll from "../../../hooks/useLockBodyScroll";
-import { ROUTES, useContext } from "../../DaimoPay";
+import { ROUTES, usePayContext } from "../../DaimoPay";
 
 import { getChainName } from "@daimo/contract";
 import { useTransition } from "react-transition-state";
@@ -200,7 +200,7 @@ const Modal: React.FC<ModalProps> = ({
   onBack,
   onInfo,
 }) => {
-  const context = useContext();
+  const context = usePayContext();
   const themeContext = useThemeContext();
   const mobile = isMobile();
   const {

--- a/packages/connectkit/src/components/Common/OptionsList/index.tsx
+++ b/packages/connectkit/src/components/Common/OptionsList/index.tsx
@@ -2,7 +2,7 @@ import { motion } from "framer-motion";
 import { useEffect } from "react";
 import { keyframes } from "styled-components";
 import styled from "../../../styles/styled";
-import { useContext } from "../../DaimoPay";
+import { usePayContext } from "../../DaimoPay";
 import { ScrollArea } from "../ScrollArea";
 import {
   OptionButton,
@@ -30,7 +30,7 @@ const OptionsList = ({
   isLoading?: boolean;
   requiredSkeletons?: number;
 }) => {
-  const { triggerResize, log } = useContext();
+  const { triggerResize, log } = usePayContext();
   const optionsLength = options.length;
 
   useEffect(() => {

--- a/packages/connectkit/src/components/Common/OrderHeader/index.tsx
+++ b/packages/connectkit/src/components/Common/OrderHeader/index.tsx
@@ -12,7 +12,7 @@ import {
 import { USDC } from "../../../assets/coins";
 import defaultTheme from "../../../constants/defaultTheme";
 import styled from "../../../styles/styled";
-import { useContext } from "../../DaimoPay";
+import { usePayContext } from "../../DaimoPay";
 import Button from "../Button";
 
 const CoinLogos = ({ $size = 24 }: { $size?: number }) => {
@@ -108,7 +108,7 @@ const Underline = styled(motion.div)`
 `;
 
 export const OrderHeader = ({ minified = false }: { minified?: boolean }) => {
-  const { paymentInfo } = useContext();
+  const { paymentInfo } = usePayContext();
 
   const amount =
     paymentInfo.daimoPayOrder?.destFinalCallTokenAmount.usd.toFixed(2);

--- a/packages/connectkit/src/components/Common/ScrollArea/index.tsx
+++ b/packages/connectkit/src/components/Common/ScrollArea/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from "react";
 import useIsMobile from "../../../hooks/useIsMobile";
-import { useContext } from "../../DaimoPay";
+import { usePayContext } from "../../DaimoPay";
 import { MoreIndicator, ScrollAreaContainer, ScrollContainer } from "./styles";
 
 const ArrowDown = () => (
@@ -31,7 +31,7 @@ export const ScrollArea = ({
   backgroundColor?: string;
   mobileDirection?: "horizontal" | "vertical";
 }) => {
-  const { log } = useContext();
+  const { log } = usePayContext();
   const ref = useRef<HTMLDivElement>(null);
   const moreRef = useRef<HTMLDivElement>(null);
 

--- a/packages/connectkit/src/components/Common/Tooltip/index.tsx
+++ b/packages/connectkit/src/components/Common/Tooltip/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import useMeasure from "react-use-measure";
-import { useContext } from "../../DaimoPay";
+import { usePayContext } from "../../DaimoPay";
 
 import { TooltipContainer, TooltipTail, TooltipWindow } from "./styles";
 import { TooltipProps, TooltipSizeProps } from "./types";
@@ -18,7 +18,7 @@ const Tooltip: React.FC<TooltipProps> = ({
   yOffset = 0,
   delay,
 }) => {
-  const context = useContext();
+  const context = usePayContext();
   const themeContext = useThemeContext();
 
   if (context.options?.hideTooltips) return <>{children}</>;

--- a/packages/connectkit/src/components/DaimoPay.tsx
+++ b/packages/connectkit/src/components/DaimoPay.tsx
@@ -106,7 +106,7 @@ type ContextValue = {
   trpc: any;
 } & useConnectCallbackProps;
 
-/** Meant for internal use. This will be non-exported in a future version of @daimo/pay */
+/** Meant for internal use. This will be non-exported in a future SDK version. */
 export const Context = createContext<ContextValue | null>(null);
 
 type DaimoPayProviderProps = {
@@ -365,6 +365,9 @@ const DaimoPayProviderWithoutSolana = ({
   );
 };
 
+/** Provides context for DaimoPayButton and hooks. Place in app root, layout, or
+ * similar.
+ */
 export const DaimoPayProvider = (props: DaimoPayProviderProps) => {
   return (
     <SolanaContextProvider solanaRpcUrl={props.solanaRpcUrl}>
@@ -373,6 +376,7 @@ export const DaimoPayProvider = (props: DaimoPayProviderProps) => {
   );
 };
 
+/** Meant for internal use. This will be non-exported in a future SDK version. */
 export const usePayContext = () => {
   const context = React.useContext(Context);
   if (!context) throw Error("DaimoPay Hook must be inside a Provider.");

--- a/packages/connectkit/src/components/DaimoPay.tsx
+++ b/packages/connectkit/src/components/DaimoPay.tsx
@@ -36,7 +36,7 @@ import {
 } from "../hooks/useConnectCallback";
 import { useThemeFont } from "../hooks/useGoogleFont";
 import { PaymentInfo, usePaymentInfo } from "../hooks/usePaymentInfo";
-import { createTrpcClient, TrpcClient } from "../utils/trpc";
+import { createTrpcClient } from "../utils/trpc";
 import { DaimoPayModal } from "./DaimoPayModal";
 import { SolanaContextProvider, SolanaWalletName } from "./contexts/solana";
 import { Web3ContextProvider } from "./contexts/web3";
@@ -102,10 +102,11 @@ type ContextValue = {
   ) => Promise<void>;
   /** Payment status & callbacks. */
   paymentInfo: PaymentInfo;
-  /** TRPC API client */
-  trpc: TrpcClient;
+  /** TRPC API client. Internal use only. */
+  trpc: any;
 } & useConnectCallbackProps;
 
+/** Meant for internal use. This will be non-exported in a future version of @daimo/pay */
 export const Context = createContext<ContextValue | null>(null);
 
 type DaimoPayProviderProps = {

--- a/packages/connectkit/src/components/DaimoPayButton/index.tsx
+++ b/packages/connectkit/src/components/DaimoPayButton/index.tsx
@@ -3,7 +3,7 @@ import { useAccount, useEnsName } from "wagmi";
 import useIsMounted from "../../hooks/useIsMounted";
 import { truncateEthAddress } from "./../../utils";
 
-import { useContext } from "../DaimoPay";
+import { usePayContext } from "../DaimoPay";
 import { TextContainer } from "./styles";
 
 import { AnimatePresence, Variants } from "framer-motion";
@@ -70,7 +70,7 @@ const DaimoPayButtonRenderer: React.FC<DaimoPayButtonRendererProps> = ({
   children,
 }) => {
   const isMounted = useIsMounted();
-  const context = useContext();
+  const context = usePayContext();
 
   const { address, chain } = useAccount();
   const isChainSupported = useChainIsSupported(chain?.id);
@@ -115,7 +115,7 @@ const DaimoPayButtonRenderer: React.FC<DaimoPayButtonRendererProps> = ({
 DaimoPayButtonRenderer.displayName = "DaimoPayButton.Custom";
 
 function DaimoPayButtonInner() {
-  const { paymentInfo } = useContext();
+  const { paymentInfo } = usePayContext();
   const label = paymentInfo?.daimoPayOrder?.metadata?.intent ?? "Pay";
 
   return (
@@ -161,7 +161,7 @@ export function DaimoPayButton({
 }: DaimoPayButtonProps) {
   const isMounted = useIsMounted();
 
-  const context = useContext();
+  const context = usePayContext();
 
   // Pre-load payment info in background.
   const { setPayId } = context.paymentInfo;

--- a/packages/connectkit/src/components/DaimoPayButton/index.tsx
+++ b/packages/connectkit/src/components/DaimoPayButton/index.tsx
@@ -64,6 +64,7 @@ type DaimoPayButtonRendererProps = {
   }) => React.ReactNode;
 };
 
+/** Like DaimoPayButton, but with custom styling. */
 const DaimoPayButtonRenderer: React.FC<DaimoPayButtonRendererProps> = ({
   payId,
   closeOnSuccess,
@@ -151,6 +152,9 @@ type DaimoPayButtonProps = {
   onClick?: (open: () => void) => void;
 };
 
+/** A button that shows the Daimo Pay checkout. Replaces the traditional
+ * Connect Wallet » approve » execute sequence with a single action.
+ */
 export function DaimoPayButton({
   payId,
   theme,

--- a/packages/connectkit/src/components/DaimoPayModal/ConnectUsing.tsx
+++ b/packages/connectkit/src/components/DaimoPayModal/ConnectUsing.tsx
@@ -2,7 +2,7 @@ import { AnimatePresence, motion } from "framer-motion";
 import { useEffect, useState } from "react";
 
 import { useWallet } from "../../wallets/useWallets";
-import { useContext } from "../DaimoPay";
+import { usePayContext } from "../DaimoPay";
 
 import ConnectWithInjector from "./ConnectWithInjector";
 import ConnectWithQRCode from "./ConnectWithQRCode";
@@ -16,7 +16,7 @@ const states = {
 };
 
 const ConnectUsing = () => {
-  const context = useContext();
+  const context = usePayContext();
   const wallet = useWallet(context.connector.id);
 
   // If cannot be scanned, display injector flow, which if extension is not installed will show CTA to install it

--- a/packages/connectkit/src/components/DaimoPayModal/ConnectWithInjector/index.tsx
+++ b/packages/connectkit/src/components/DaimoPayModal/ConnectWithInjector/index.tsx
@@ -29,7 +29,7 @@ import useLocales from "../../../hooks/useLocales";
 import { detectBrowser, isWalletConnectConnector } from "../../../utils";
 import { useWallet } from "../../../wallets/useWallets";
 import BrowserIcon from "../../Common/BrowserIcon";
-import { useContext } from "../../DaimoPay";
+import { usePayContext } from "../../DaimoPay";
 import CircleSpinner from "../../Spinners/CircleSpinner";
 
 export const states = {
@@ -124,7 +124,7 @@ const ConnectWithInjector: React.FC<{
     },
   });
 
-  const { triggerResize, connector: c } = useContext();
+  const { triggerResize, connector: c } = usePayContext();
   const id = c.id;
   const wallet = useWallet(id);
 

--- a/packages/connectkit/src/components/DaimoPayModal/ConnectWithQRCode.tsx
+++ b/packages/connectkit/src/components/DaimoPayModal/ConnectWithQRCode.tsx
@@ -1,12 +1,9 @@
 import React from "react";
-import { ROUTES, useContext } from "../DaimoPay";
+import { ROUTES, usePayContext } from "../DaimoPay";
 
 import { useWalletConnectModal } from "../../hooks/useWalletConnectModal";
 
-import {
-  detectBrowser,
-  isWalletConnectConnector
-} from "../../utils";
+import { detectBrowser, isWalletConnectConnector } from "../../utils";
 
 import { OrDivider } from "../Common/Modal";
 import { ModalContent, PageContent } from "../Common/Modal/styles";
@@ -24,7 +21,7 @@ import { useWeb3 } from "../contexts/web3";
 const ConnectWithQRCode: React.FC<{
   switchConnectMethod: (id?: string) => void;
 }> = ({ switchConnectMethod }) => {
-  const context = useContext();
+  const context = usePayContext();
 
   const id = context.connector.id;
 

--- a/packages/connectkit/src/components/DaimoPayModal/index.tsx
+++ b/packages/connectkit/src/components/DaimoPayModal/index.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { useAccount } from "wagmi";
 import { CustomTheme, Languages, Mode, Theme } from "../../types";
 import Modal from "../Common/Modal";
-import { ROUTES, useContext } from "../DaimoPay";
+import { ROUTES, usePayContext } from "../DaimoPay";
 
 import About from "../Pages/About";
 import Connectors from "../Pages/Connectors";
@@ -40,7 +40,7 @@ export const DaimoPayModal: React.FC<{
   customTheme = customThemeDefault,
   lang = "en-US",
 }) => {
-  const context = useContext();
+  const context = usePayContext();
   const {
     setSelectedExternalOption,
     setSelectedTokenOption,

--- a/packages/connectkit/src/components/NetworkButton/index.tsx
+++ b/packages/connectkit/src/components/NetworkButton/index.tsx
@@ -12,7 +12,7 @@ import Chain from "../Common/Chain";
 import ChainSelectDropdown from "../Common/ChainSelectDropdown";
 import DynamicContainer from "../Common/DynamicContainer";
 import ThemedButton from "../Common/ThemedButton";
-import { useContext } from "../DaimoPay";
+import { usePayContext } from "../DaimoPay";
 import { DaimoPayThemeProvider } from "../DaimoPayThemeProvider/DaimoPayThemeProvider";
 import styled from "./../../styles/styled";
 
@@ -49,7 +49,7 @@ const NetworkButton: React.FC<NetworkButtonProps & All> = ({
   hideIcon,
   hideName,
 }) => {
-  const context = useContext();
+  const context = usePayContext();
   const isMounted = useIsMounted();
 
   const [open, setOpen] = useState(false);

--- a/packages/connectkit/src/components/Pages/About/index.tsx
+++ b/packages/connectkit/src/components/Pages/About/index.tsx
@@ -22,14 +22,14 @@ import useLocales from "../../../hooks/useLocales";
 import Button from "../../Common/Button";
 import FitText from "../../Common/FitText";
 import { OrDivider } from "../../Common/Modal";
-import { useContext } from "../../DaimoPay";
+import { usePayContext } from "../../DaimoPay";
 import { Easing, SlideOne, SlideThree, SlideTwo } from "./graphics";
 
 const About: React.FC = () => {
   const locales = useLocales({
     //CONNECTORNAME: connector.name,
   });
-  const context = useContext();
+  const context = usePayContext();
 
   const ctaUrl =
     context.options?.ethereumOnboardingUrl ?? locales.aboutScreen_ctaUrl;

--- a/packages/connectkit/src/components/Pages/Confirmation/index.tsx
+++ b/packages/connectkit/src/components/Pages/Confirmation/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useContext } from "../../DaimoPay";
+import { usePayContext } from "../../DaimoPay";
 
 import { ModalContent, ModalH1, PageContent } from "../../Common/Modal/styles";
 
@@ -15,7 +15,7 @@ import styled from "../../../styles/styled";
 import PoweredByFooter from "../../Common/PoweredByFooter";
 
 const Confirmation: React.FC = () => {
-  const { paymentInfo } = useContext();
+  const { paymentInfo } = usePayContext();
   const { daimoPayOrder } = paymentInfo;
 
   const { done, txURL } = (() => {

--- a/packages/connectkit/src/components/Pages/Connectors/index.tsx
+++ b/packages/connectkit/src/components/Pages/Connectors/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ROUTES, useContext } from "../../DaimoPay";
+import { ROUTES, usePayContext } from "../../DaimoPay";
 
 import WalletIcon from "../../../assets/wallet";
 import {
@@ -23,7 +23,7 @@ import ConnectorList from "../../Common/ConnectorList";
 import { OrderHeader } from "../../Common/OrderHeader";
 
 const Wallets: React.FC = () => {
-  const context = useContext();
+  const context = usePayContext();
   const locales = useLocales({});
 
   const isMobile = useIsMobile();

--- a/packages/connectkit/src/components/Pages/DownloadApp/index.tsx
+++ b/packages/connectkit/src/components/Pages/DownloadApp/index.tsx
@@ -1,4 +1,3 @@
-
 import {
   ModalBody,
   ModalContent,
@@ -9,10 +8,10 @@ import CustomQRCode from "../../Common/CustomQRCode";
 
 import useLocales from "../../../hooks/useLocales";
 import { useWallet } from "../../../wallets/useWallets";
-import { useContext } from "../../DaimoPay";
+import { usePayContext } from "../../DaimoPay";
 
 const DownloadApp = () => {
-  const context = useContext();
+  const context = usePayContext();
   const wallet = useWallet(context.connector.id);
 
   const locales = useLocales({

--- a/packages/connectkit/src/components/Pages/MobileConnectors/index.tsx
+++ b/packages/connectkit/src/components/Pages/MobileConnectors/index.tsx
@@ -20,7 +20,7 @@ import CopyToClipboard from "../../Common/CopyToClipboard";
 import { ScrollArea } from "../../Common/ScrollArea";
 import { Spinner } from "../../Common/Spinner";
 import { useWeb3 } from "../../contexts/web3";
-import { useContext } from "../../DaimoPay";
+import { usePayContext } from "../../DaimoPay";
 
 const MoreIcon = (
   <svg
@@ -40,7 +40,7 @@ const MoreIcon = (
 );
 
 const MobileConnectors: React.FC = () => {
-  const context = useContext();
+  const context = usePayContext();
   const locales = useLocales();
 
   const {

--- a/packages/connectkit/src/components/Pages/Onboarding/index.tsx
+++ b/packages/connectkit/src/components/Pages/Onboarding/index.tsx
@@ -22,10 +22,10 @@ import {
 
 import useLocales from "../../../hooks/useLocales";
 import Button from "../../Common/Button";
-import { useContext } from "../../DaimoPay";
+import { usePayContext } from "../../DaimoPay";
 
 const Introduction: React.FC = () => {
-  const context = useContext();
+  const context = usePayContext();
   const locales = useLocales({});
 
   const ctaUrl =

--- a/packages/connectkit/src/components/Pages/PayWithToken/index.tsx
+++ b/packages/connectkit/src/components/Pages/PayWithToken/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { ROUTES, useContext } from "../../DaimoPay";
+import { ROUTES, usePayContext } from "../../DaimoPay";
 
 import { ModalContent, ModalH1, PageContent } from "../../Common/Modal/styles";
 
@@ -20,7 +20,7 @@ enum PayState {
 }
 
 const PayWithToken: React.FC = () => {
-  const { triggerResize, paymentInfo, setRoute, log } = useContext();
+  const { triggerResize, paymentInfo, setRoute, log } = usePayContext();
   const { selectedTokenOption, payWithToken } = paymentInfo;
   const [payState, setPayState] = useState<PayState>(
     PayState.RequestingPayment,

--- a/packages/connectkit/src/components/Pages/SelectDepositAddressChain/index.tsx
+++ b/packages/connectkit/src/components/Pages/SelectDepositAddressChain/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ROUTES, useContext } from "../../DaimoPay";
+import { ROUTES, usePayContext } from "../../DaimoPay";
 
 import { ModalContent, ModalH1, PageContent } from "../../Common/Modal/styles";
 
@@ -8,7 +8,7 @@ import OptionsList from "../../Common/OptionsList";
 import { OrderHeader } from "../../Common/OrderHeader";
 
 const SelectDepositAddressChain: React.FC = () => {
-  const { setRoute, paymentInfo } = useContext();
+  const { setRoute, paymentInfo } = usePayContext();
   const { setSelectedDepositAddressOption, depositAddressOptions } =
     paymentInfo;
 

--- a/packages/connectkit/src/components/Pages/SelectMethod/index.tsx
+++ b/packages/connectkit/src/components/Pages/SelectMethod/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ROUTES, useContext } from "../../DaimoPay";
+import { ROUTES, usePayContext } from "../../DaimoPay";
 
 import { PageContent } from "../../Common/Modal/styles";
 
@@ -36,7 +36,7 @@ function getBestUnconnectedWalletIcons(connector: Connector | undefined) {
 
 function getSolanaOption() {
   const { wallets } = useWallet();
-  const { setRoute } = useContext();
+  const { setRoute } = usePayContext();
 
   if (wallets.length === 0) return null;
 
@@ -54,7 +54,7 @@ function getDepositAddressOption(depositAddressOptions: {
   loading: boolean;
   options: DepositAddressPaymentOptionMetadata[];
 }) {
-  const { setRoute } = useContext();
+  const { setRoute } = usePayContext();
 
   console.log(
     `[SELECT_METHOD] depositAddressOptions: ${JSON.stringify(
@@ -85,7 +85,7 @@ const SelectMethod: React.FC = () => {
   const { address, isConnected, connector } = useAccount();
   const { disconnectAsync } = useDisconnect();
 
-  const { setRoute, paymentInfo, log } = useContext();
+  const { setRoute, paymentInfo, log } = usePayContext();
   const {
     setSelectedExternalOption,
     externalPaymentOptions,

--- a/packages/connectkit/src/components/Pages/SelectToken/index.tsx
+++ b/packages/connectkit/src/components/Pages/SelectToken/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ROUTES, useContext } from "../../DaimoPay";
+import { ROUTES, usePayContext } from "../../DaimoPay";
 
 import { ModalContent, ModalH1, PageContent } from "../../Common/Modal/styles";
 
@@ -45,7 +45,7 @@ const ChainContainer = styled(motion.div)`
 `;
 
 const SelectToken: React.FC = () => {
-  const { setRoute, paymentInfo } = useContext();
+  const { setRoute, paymentInfo } = usePayContext();
   const { setSelectedTokenOption, walletPaymentOptions } = paymentInfo;
 
   return (

--- a/packages/connectkit/src/components/Pages/Solana/ConnectSolana/index.tsx
+++ b/packages/connectkit/src/components/Pages/Solana/ConnectSolana/index.tsx
@@ -10,10 +10,10 @@ import { useWallet } from "@solana/wallet-adapter-react";
 import Button from "../../../Common/Button";
 import OptionsList from "../../../Common/OptionsList";
 import { OrderHeader } from "../../../Common/OrderHeader";
-import { ROUTES, useContext } from "../../../DaimoPay";
+import { ROUTES, usePayContext } from "../../../DaimoPay";
 
 const ConnectSolana: React.FC = () => {
-  const { setSolanaConnector, setRoute } = useContext();
+  const { setSolanaConnector, setRoute } = usePayContext();
   const solanaWallets = useWallet();
 
   const options = solanaWallets.wallets.map((wallet) => ({

--- a/packages/connectkit/src/components/Pages/Solana/ConnectorSolana/index.tsx
+++ b/packages/connectkit/src/components/Pages/Solana/ConnectorSolana/index.tsx
@@ -10,7 +10,7 @@ import {
 import { useWallet } from "@solana/wallet-adapter-react";
 import { AnimatePresence, motion } from "framer-motion";
 import styled from "../../../../styles/styled";
-import { ROUTES, useContext } from "../../../DaimoPay";
+import { ROUTES, usePayContext } from "../../../DaimoPay";
 import SquircleSpinner from "../../../Spinners/SquircleSpinner";
 import { LoadingContainer } from "../../WaitingOther";
 
@@ -18,7 +18,7 @@ const ConnectSolana: React.FC = () => {
   const solanaWallets = useWallet();
   const isConnected = solanaWallets.connected;
 
-  const { solanaConnector, setRoute } = useContext();
+  const { solanaConnector, setRoute } = usePayContext();
 
   const selectedWallet = solanaWallets.wallets.find(
     (wallet) => wallet.adapter.name === solanaConnector,

--- a/packages/connectkit/src/components/Pages/Solana/PayWithSolanaToken/index.tsx
+++ b/packages/connectkit/src/components/Pages/Solana/PayWithSolanaToken/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { ROUTES, useContext } from "../../../DaimoPay";
+import { ROUTES, usePayContext } from "../../../DaimoPay";
 
 import { WalletSignTransactionError } from "@solana/wallet-adapter-base";
 import {
@@ -23,7 +23,7 @@ enum PayState {
 }
 
 const PayWithSolanaToken: React.FC = () => {
-  const { triggerResize, paymentInfo, setRoute } = useContext();
+  const { triggerResize, paymentInfo, setRoute } = usePayContext();
   const { selectedSolanaTokenOption, payWithSolanaToken } = paymentInfo;
   const [payState, setPayState] = useState<PayState>(
     PayState.RequestingPayment,

--- a/packages/connectkit/src/components/Pages/Solana/SelectSolanaToken/index.tsx
+++ b/packages/connectkit/src/components/Pages/Solana/SelectSolanaToken/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ROUTES, useContext } from "../../../DaimoPay";
+import { ROUTES, usePayContext } from "../../../DaimoPay";
 
 import {
   ModalContent,
@@ -13,7 +13,7 @@ import OptionsList from "../../../Common/OptionsList";
 import { OrderHeader } from "../../../Common/OrderHeader";
 
 const SelectSolanaToken: React.FC = () => {
-  const { paymentInfo, setRoute } = useContext();
+  const { paymentInfo, setRoute } = usePayContext();
   const { solanaPaymentOptions, setSelectedSolanaTokenOption } = paymentInfo;
 
   return (

--- a/packages/connectkit/src/components/Pages/WaitingDepositAddress/index.tsx
+++ b/packages/connectkit/src/components/Pages/WaitingDepositAddress/index.tsx
@@ -13,13 +13,17 @@ import {
   getAddressContraction,
 } from "@daimo/common";
 import ScanIconWithLogos from "../../../assets/ScanIconWithLogos";
+import type { TrpcClient } from "../../../utils/trpc";
 import Button from "../../Common/Button";
 import CopyToClipboard from "../../Common/CopyToClipboard";
 import CustomQRCode from "../../Common/CustomQRCode";
 import { OrDivider } from "../../Common/Modal";
 
 const WaitingDepositAddress: React.FC = () => {
-  const { trpc, triggerResize, paymentInfo, setRoute } = usePayContext();
+  const context = usePayContext();
+  const { triggerResize, paymentInfo, setRoute } = context;
+  const trpc = context.trpc as TrpcClient;
+
   const { daimoPayOrder, payWithDepositAddress, selectedDepositAddressOption } =
     paymentInfo;
 

--- a/packages/connectkit/src/components/Pages/WaitingDepositAddress/index.tsx
+++ b/packages/connectkit/src/components/Pages/WaitingDepositAddress/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { ROUTES, useContext } from "../../DaimoPay";
+import { ROUTES, usePayContext } from "../../DaimoPay";
 
 import {
   ModalBody,
@@ -13,14 +13,13 @@ import {
   getAddressContraction,
 } from "@daimo/common";
 import ScanIconWithLogos from "../../../assets/ScanIconWithLogos";
-import { trpc } from "../../../utils/trpc";
 import Button from "../../Common/Button";
 import CopyToClipboard from "../../Common/CopyToClipboard";
 import CustomQRCode from "../../Common/CustomQRCode";
 import { OrDivider } from "../../Common/Modal";
 
 const WaitingDepositAddress: React.FC = () => {
-  const { triggerResize, paymentInfo, setRoute } = useContext();
+  const { trpc, triggerResize, paymentInfo, setRoute } = usePayContext();
   const { daimoPayOrder, payWithDepositAddress, selectedDepositAddressOption } =
     paymentInfo;
 

--- a/packages/connectkit/src/components/Pages/WaitingOther/index.tsx
+++ b/packages/connectkit/src/components/Pages/WaitingOther/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { ROUTES, useContext } from "../../DaimoPay";
+import { ROUTES, usePayContext } from "../../DaimoPay";
 
 import {
   ModalBody,
@@ -12,13 +12,12 @@ import { AnimatePresence, motion } from "framer-motion";
 import { css } from "styled-components";
 import { ExternalLinkIcon } from "../../../assets/icons";
 import styled from "../../../styles/styled";
-import { trpc } from "../../../utils/trpc";
 import Button from "../../Common/Button";
 import CircleSpinner from "../../Spinners/CircleSpinner";
 import SquircleSpinner from "../../Spinners/SquircleSpinner";
 
 const WaitingOther: React.FC = () => {
-  const { triggerResize, paymentInfo, setRoute } = useContext();
+  const { trpc, triggerResize, paymentInfo, setRoute } = usePayContext();
   const {
     selectedExternalOption,
     payWithExternal,

--- a/packages/connectkit/src/components/Pages/WaitingOther/index.tsx
+++ b/packages/connectkit/src/components/Pages/WaitingOther/index.tsx
@@ -12,12 +12,16 @@ import { AnimatePresence, motion } from "framer-motion";
 import { css } from "styled-components";
 import { ExternalLinkIcon } from "../../../assets/icons";
 import styled from "../../../styles/styled";
+import type { TrpcClient } from "../../../utils/trpc";
 import Button from "../../Common/Button";
 import CircleSpinner from "../../Spinners/CircleSpinner";
 import SquircleSpinner from "../../Spinners/SquircleSpinner";
 
 const WaitingOther: React.FC = () => {
-  const { trpc, triggerResize, paymentInfo, setRoute } = usePayContext();
+  const context = usePayContext();
+  const { triggerResize, paymentInfo, setRoute } = context;
+  const trpc = context.trpc as TrpcClient;
+
   const {
     selectedExternalOption,
     payWithExternal,

--- a/packages/connectkit/src/defaultConfig.ts
+++ b/packages/connectkit/src/defaultConfig.ts
@@ -50,6 +50,7 @@ export const REQUIRED_CHAINS: CreateConfigParameters["chains"] = [
   baseSepolia,
 ];
 
+/** A utility for use with wagmi's createConfig(). */
 const defaultConfig = ({
   appName = "Daimo Pay",
   appIcon,

--- a/packages/connectkit/src/hooks/connectors/useWalletConnectUri.ts
+++ b/packages/connectkit/src/hooks/connectors/useWalletConnectUri.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 
 import { Connector, useAccount } from "wagmi";
-import { useContext } from "../../components/DaimoPay";
+import { usePayContext } from "../../components/DaimoPay";
 import { useConnect } from "../useConnect";
 import { useWalletConnectConnector } from "./../useConnectors";
 
@@ -14,7 +14,7 @@ export function useWalletConnectUri(
     enabled: true,
   },
 ) {
-  const { log } = useContext();
+  const { log } = usePayContext();
 
   const [uri, setUri] = useState<string | undefined>(undefined);
 

--- a/packages/connectkit/src/hooks/useChainIsSupported.ts
+++ b/packages/connectkit/src/hooks/useChainIsSupported.ts
@@ -1,5 +1,6 @@
 import { useConfig } from "wagmi";
 
+/** Determines whether the current wagmi configuration supports a given chain. */
 export function useChainIsSupported(chainId?: number): boolean | null {
   const { chains } = useConfig();
   if (!chainId) return false;

--- a/packages/connectkit/src/hooks/useChains.ts
+++ b/packages/connectkit/src/hooks/useChains.ts
@@ -1,6 +1,7 @@
 import { Chain } from "viem";
 import { useConfig } from "wagmi";
 
+/** Returns currently configured wagmi chains. */
 export function useChains() {
   const wagmi = useConfig();
   const chains = wagmi?.chains ?? [];

--- a/packages/connectkit/src/hooks/useConnect.tsx
+++ b/packages/connectkit/src/hooks/useConnect.tsx
@@ -9,10 +9,10 @@ import {
   type UseConnectParameters,
   useConnect as wagmiUseConnect,
 } from "wagmi";
-import { useContext } from "../components/DaimoPay";
+import { usePayContext } from "../components/DaimoPay";
 
 export function useConnect({ ...props }: UseConnectParameters = {}) {
-  const context = useContext();
+  const context = usePayContext();
 
   const { connect, connectAsync, connectors, ...rest } = wagmiUseConnect({
     ...props,

--- a/packages/connectkit/src/hooks/useDaimoPayStatus.ts
+++ b/packages/connectkit/src/hooks/useDaimoPayStatus.ts
@@ -4,10 +4,10 @@ import {
   DaimoPayOrderStatusSource,
   writeDaimoPayOrderID,
 } from "@daimo/common";
-import { useContext } from "../components/DaimoPay";
+import { usePayContext } from "../components/DaimoPay";
 
 export function useDaimoPayStatus() {
-  const { paymentInfo } = useContext();
+  const { paymentInfo } = usePayContext();
 
   const status = (() => {
     if (!paymentInfo || !paymentInfo.daimoPayOrder) return undefined;

--- a/packages/connectkit/src/hooks/useDaimoPayStatus.ts
+++ b/packages/connectkit/src/hooks/useDaimoPayStatus.ts
@@ -5,38 +5,39 @@ import {
   writeDaimoPayOrderID,
 } from "@daimo/common";
 import { usePayContext } from "../components/DaimoPay";
+import { PaymentStatus } from "../types";
 
-export function useDaimoPayStatus() {
+/** Returns the current payment, or undefined if there is none.
+ *
+ * Status values:
+ * - `payment_pending` - the user has not paid yet
+ * - `payment_started` - the user has paid & payment is in progress. This status
+ *    typically lasts a few seconds.
+ * - `payment_completed` - the final call or transfer succeeded
+ * - `payment_bounced` - the final call or transfer reverted. Funds were sent
+ *    to the payment's configured refund address on the destination chain.
+ */
+export function useDaimoPayStatus():
+  | { paymentId: string; status: PaymentStatus }
+  | undefined {
   const { paymentInfo } = usePayContext();
+  if (!paymentInfo || !paymentInfo.daimoPayOrder) return undefined;
 
-  const status = (() => {
-    if (!paymentInfo || !paymentInfo.daimoPayOrder) return undefined;
-    const order = paymentInfo.daimoPayOrder;
-    const paymentId = writeDaimoPayOrderID(order.id);
-    if (order.mode === DaimoPayOrderMode.HYDRATED) {
-      if (order.intentStatus != DaimoPayIntentStatus.PENDING) {
-        return {
-          status:
-            order.intentStatus === DaimoPayIntentStatus.SUCCESSFUL
-              ? "payment_completed"
-              : "payment_bounced",
-          paymentId,
-        };
-      } else if (
-        order.sourceStatus != DaimoPayOrderStatusSource.WAITING_PAYMENT
-      ) {
-        return {
-          status: "payment_started" as const,
-          paymentId,
-        };
+  const order = paymentInfo.daimoPayOrder;
+  const paymentId = writeDaimoPayOrderID(order.id);
+  if (order.mode === DaimoPayOrderMode.HYDRATED) {
+    if (order.intentStatus !== DaimoPayIntentStatus.PENDING) {
+      if (order.intentStatus === DaimoPayIntentStatus.SUCCESSFUL) {
+        return { paymentId, status: "payment_completed" };
+      } else {
+        return { paymentId, status: "payment_bounced" };
       }
+    } else if (
+      order.sourceStatus !== DaimoPayOrderStatusSource.WAITING_PAYMENT
+    ) {
+      return { paymentId, status: "payment_started" };
     }
+  }
 
-    return {
-      status: "payment_pending" as const,
-      paymentId,
-    };
-  })();
-
-  return status;
+  return { paymentId, status: "payment_pending" };
 }

--- a/packages/connectkit/src/hooks/useDepositAddressOptions.ts
+++ b/packages/connectkit/src/hooks/useDepositAddressOptions.ts
@@ -1,10 +1,12 @@
 import { DepositAddressPaymentOptionMetadata } from "@daimo/common";
 import { useEffect, useState } from "react";
-import { trpc } from "../utils/trpc";
+import { TrpcClient } from "../utils/trpc";
 
 export function useDepositAddressOptions({
+  trpc,
   usdRequired,
 }: {
+  trpc: TrpcClient;
   usdRequired: number;
 }) {
   const [options, setOptions] = useState<DepositAddressPaymentOptionMetadata[]>(

--- a/packages/connectkit/src/hooks/useExternalPaymentOptions.ts
+++ b/packages/connectkit/src/hooks/useExternalPaymentOptions.ts
@@ -4,7 +4,7 @@ import {
   PlatformType,
 } from "@daimo/common";
 import { useEffect, useState } from "react";
-import { trpc } from "../utils/trpc";
+import { TrpcClient } from "../utils/trpc";
 
 const DEFAULT_EXTERNAL_PAYMENT_OPTIONS = [
   ExternalPaymentOptions.Coinbase,
@@ -14,10 +14,12 @@ const DEFAULT_EXTERNAL_PAYMENT_OPTIONS = [
 ];
 
 export function useExternalPaymentOptions({
+  trpc,
   filterIds,
   usdRequired,
   platform,
 }: {
+  trpc: TrpcClient;
   filterIds: string[] | undefined;
   usdRequired: number | undefined;
   platform: PlatformType | undefined;

--- a/packages/connectkit/src/hooks/useIsMounted.tsx
+++ b/packages/connectkit/src/hooks/useIsMounted.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 
+/** Utility. Returns false on first render, true after.
+ * Useful for apps with SSR, for example. */
 export default function useIsMounted() {
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);

--- a/packages/connectkit/src/hooks/useLocales.tsx
+++ b/packages/connectkit/src/hooks/useLocales.tsx
@@ -1,12 +1,12 @@
 import React, { useMemo } from "react";
 import Logos from "../assets/logos";
 
-import { useContext } from "../components/DaimoPay";
+import { usePayContext } from "../components/DaimoPay";
 
 import { getLocale } from "./../localizations";
 
 export default function useLocales(replacements?: any) {
-  const context = useContext();
+  const context = usePayContext();
   const language = context.options?.language ?? "en-US";
 
   const translations = useMemo(() => {

--- a/packages/connectkit/src/hooks/useLockBodyScroll.ts
+++ b/packages/connectkit/src/hooks/useLockBodyScroll.ts
@@ -1,5 +1,5 @@
 import { useEffect, useLayoutEffect, useState } from "react";
-import { useContext } from "../components/DaimoPay";
+import { usePayContext } from "../components/DaimoPay";
 
 const useIsomorphicLayoutEffect =
   typeof window !== "undefined" ? useLayoutEffect : useEffect;
@@ -7,7 +7,7 @@ const useIsomorphicLayoutEffect =
 export default function useLockBodyScroll(initialLocked: boolean) {
   const [locked, setLocked] = useState(initialLocked);
 
-  const context = useContext();
+  const context = usePayContext();
 
   useIsomorphicLayoutEffect(() => {
     if (!locked) return;

--- a/packages/connectkit/src/hooks/useModal.ts
+++ b/packages/connectkit/src/hooks/useModal.ts
@@ -1,4 +1,4 @@
-import { ROUTES, useContext } from "../components/DaimoPay";
+import { ROUTES, usePayContext } from "../components/DaimoPay";
 import {
   useConnectCallback,
   useConnectCallbackProps,
@@ -7,7 +7,7 @@ import {
 type UseModalProps = {} & useConnectCallbackProps;
 
 export const useModal = ({ onConnect, onDisconnect }: UseModalProps = {}) => {
-  const context = useContext();
+  const context = usePayContext();
 
   useConnectCallback({
     onConnect,

--- a/packages/connectkit/src/hooks/usePayWithSolanaToken.ts
+++ b/packages/connectkit/src/hooks/usePayWithSolanaToken.ts
@@ -8,14 +8,21 @@ import {
 import { useConnection, useWallet } from "@solana/wallet-adapter-react";
 import { VersionedTransaction } from "@solana/web3.js";
 import { hexToBytes } from "viem";
-import { trpc } from "../utils/trpc";
+import { TrpcClient } from "../utils/trpc";
 
-export function usePayWithSolanaToken(
-  orderId: bigint | undefined,
-  setDaimoPayOrder: (order: DaimoPayOrder) => void,
-  chosenFinalTokenAmount: BigIntStr | undefined,
-  platform: PlatformType | undefined,
-) {
+export function usePayWithSolanaToken({
+  trpc,
+  orderId,
+  setDaimoPayOrder,
+  chosenFinalTokenAmount,
+  platform,
+}: {
+  trpc: TrpcClient;
+  orderId: bigint | undefined;
+  setDaimoPayOrder: (order: DaimoPayOrder) => void;
+  chosenFinalTokenAmount: BigIntStr | undefined;
+  platform: PlatformType | undefined;
+}) {
   const { connection } = useConnection();
   const wallet = useWallet();
 

--- a/packages/connectkit/src/hooks/useSolanaPaymentOptions.ts
+++ b/packages/connectkit/src/hooks/useSolanaPaymentOptions.ts
@@ -1,14 +1,16 @@
 import { useEffect, useState } from "react";
-import { trpc } from "../utils/trpc";
+import { TrpcClient } from "../utils/trpc";
 
 export type SolanaPaymentOption = Awaited<
-  ReturnType<typeof trpc.getSolanaPaymentOptions.query>
+  ReturnType<TrpcClient["getSolanaPaymentOptions"]["query"]>
 >[0];
 
 export function useSolanaPaymentOptions({
+  trpc,
   address,
   usdRequired,
 }: {
+  trpc: TrpcClient;
   address: string | undefined;
   usdRequired: number | undefined;
 }) {

--- a/packages/connectkit/src/hooks/useWalletConnectModal.tsx
+++ b/packages/connectkit/src/hooks/useWalletConnectModal.tsx
@@ -1,13 +1,13 @@
 import { useState } from "react";
 import { Connector, CreateConnectorFn } from "wagmi";
 import { walletConnect } from "wagmi/connectors";
-import { useContext } from "../components/DaimoPay";
+import { usePayContext } from "../components/DaimoPay";
 
 import { isWalletConnectConnector } from "../utils";
 import { useConnect } from "./useConnect";
 
 export function useWalletConnectModal() {
-  const { log } = useContext();
+  const { log } = usePayContext();
   const { connectAsync, connectors } = useConnect();
   const [isOpen, setIsOpen] = useState(false);
 

--- a/packages/connectkit/src/hooks/useWalletPaymentOptions.ts
+++ b/packages/connectkit/src/hooks/useWalletPaymentOptions.ts
@@ -1,16 +1,18 @@
 import { useEffect, useState } from "react";
-import { trpc } from "../utils/trpc";
+import { TrpcClient } from "../utils/trpc";
 
 /** Wallet payment options. User picks one. */
 export type WalletPaymentOption = Awaited<
-  ReturnType<typeof trpc.getWalletPaymentOptions.query>
+  ReturnType<TrpcClient["getWalletPaymentOptions"]["query"]>
 >[0];
 
 export function useWalletPaymentOptions({
+  trpc,
   address,
   usdRequired,
   destChainId,
 }: {
+  trpc: TrpcClient;
   address: string | undefined;
   usdRequired: number | undefined;
   destChainId: number | undefined;

--- a/packages/connectkit/src/index.ts
+++ b/packages/connectkit/src/index.ts
@@ -18,4 +18,5 @@ export { default as ChainIcon } from "./components/Common/Chain";
 export { useChainIsSupported } from "./hooks/useChainIsSupported";
 export { useChains } from "./hooks/useChains";
 export { useDaimoPayStatus } from "./hooks/useDaimoPayStatus";
-export { default as useIsMounted } from "./hooks/useIsMounted"; // Useful for apps that use SSR
+
+export { default as useIsMounted } from "./hooks/useIsMounted";

--- a/packages/connectkit/src/index.ts
+++ b/packages/connectkit/src/index.ts
@@ -2,7 +2,12 @@ export { default as getDefaultConfig } from "./defaultConfig";
 export * as Types from "./types";
 export { wallets } from "./wallets";
 
-export { Context, DaimoPayProvider } from "./components/DaimoPay";
+// TODO: remove Context and usePayContext exports following SDK refactor.
+export {
+  Context,
+  DaimoPayProvider,
+  usePayContext,
+} from "./components/DaimoPay";
 export { DaimoPayButton } from "./components/DaimoPayButton";
 export { useModal } from "./hooks/useModal";
 

--- a/packages/connectkit/src/types.ts
+++ b/packages/connectkit/src/types.ts
@@ -55,3 +55,10 @@ export type DaimoPayContextOptions = {
 export type DaimoPayModalOptions = {
   closeOnSuccess?: boolean;
 };
+
+/** Payment status. See webhooks and React useDaimoPayStatus() hook. */
+export type PaymentStatus =
+  | "payment_pending"
+  | "payment_started"
+  | "payment_completed"
+  | "payment_bounced";

--- a/packages/connectkit/src/utils/trpc.ts
+++ b/packages/connectkit/src/utils/trpc.ts
@@ -14,5 +14,5 @@ export function createTrpcClient(apiUrl: string): TrpcClient {
         url: apiUrl,
       }),
     ],
-  }) as any;
+  });
 }

--- a/packages/connectkit/src/utils/trpc.ts
+++ b/packages/connectkit/src/utils/trpc.ts
@@ -1,14 +1,18 @@
-// TODO: re-enable for dev only in rollup.
-// import { AppRouter } from "@daimo/pay-api";
-import { createTRPCClient, httpBatchLink } from "@trpc/client";
+import type { AppRouter } from "@daimo/pay-api";
+import {
+  CreateTRPCClient,
+  createTRPCClient,
+  httpBatchLink,
+} from "@trpc/client";
 
-// TODO: env var in build
-export const apiUrl = "https://pay-api.daimo.xyz";
+export type TrpcClient = CreateTRPCClient<AppRouter>;
 
-export const trpc = createTRPCClient({
-  links: [
-    httpBatchLink({
-      url: apiUrl,
-    }),
-  ],
-}) as any;
+export function createTrpcClient(apiUrl: string): TrpcClient {
+  return createTRPCClient<AppRouter>({
+    links: [
+      httpBatchLink({
+        url: apiUrl,
+      }),
+    ],
+  }) as any;
+}

--- a/packages/connectkit/src/wallets/useWallets.tsx
+++ b/packages/connectkit/src/wallets/useWallets.tsx
@@ -1,6 +1,6 @@
 import { Connector } from "wagmi";
 
-import { useContext } from "../components/DaimoPay";
+import { usePayContext } from "../components/DaimoPay";
 import { useConnectors } from "../hooks/useConnectors";
 import { isCoinbaseWalletConnector, isInjectedConnector } from "../utils";
 import { WalletConfigProps, walletConfigs } from "./walletConfigs";
@@ -19,7 +19,7 @@ export const useWallet = (id: string): WalletProps | null => {
 };
 export const useWallets = (): WalletProps[] => {
   const connectors = useConnectors();
-  const context = useContext();
+  const context = usePayContext();
 
   const wallets = connectors.map((connector): WalletProps => {
     // use overrides


### PR DESCRIPTION
New internal parameter, used in our own Pay webapp: pass in `payApiUrl` so that the surrounding page and Pay SDK use the same TRPC API. This fixes local dev and staging.