### PR TITLE
release: 0.3.21

### DIFF
--- a/packages/connectkit/package.json
+++ b/packages/connectkit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@daimo/pay",
   "private": false,
-  "version": "0.3.20",
+  "version": "0.3.21",
   "author": "Daimo",
   "homepage": "https://pay.daimo.com",
   "license": "BSD-2-Clause license",


### PR DESCRIPTION
No actual changes, just building + publishing cleanly to fix the broken `payApiUrl` default in `0.3.20`.