### PR TITLE
paykit: 1.1.0, usePayContext()

### DIFF
--- a/packages/connectkit/package.json
+++ b/packages/connectkit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@daimo/pay",
   "private": false,
-  "version": "1.0.9",
+  "version": "1.1.0",
   "author": "Daimo",
   "homepage": "https://pay.daimo.com",
   "license": "BSD-2-Clause license",

--- a/packages/connectkit/src/index.ts
+++ b/packages/connectkit/src/index.ts
@@ -22,3 +22,9 @@ export { wallets } from "./wallets";
 
 // Export utilities.
 export * from "./utils/exports";
+
+// TODO: expose this more selectively.
+export {
+  Context as DaimoPayContext,
+  usePayContext,
+} from "./components/DaimoPay";


### PR DESCRIPTION
We cannot force all users to go through DaimoPayButton.

There are cases (Super is one of them) where there is no clean way to do this:
- Cart modifiable until the moment the user clicks the checkout button
- At that point, they save the cart to backend + generate a payId for tracking against future webhooks
- ...once that returns, the payId must be displayed immediately

In future, we can come up with a more selective way to expose this. For now, `usePayContext`
