### PR TITLE
paykit version 1.1.2: confirmation message, defaultOpen parameter

### DIFF
--- a/packages/connectkit/package.json
+++ b/packages/connectkit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@daimo/pay",
   "private": false,
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": "Daimo",
   "homepage": "https://pay.daimo.com",
   "license": "BSD-2-Clause license",

--- a/packages/connectkit/src/components/DaimoPay.tsx
+++ b/packages/connectkit/src/components/DaimoPay.tsx
@@ -106,6 +106,11 @@ type ContextValue = {
   paymentState: PaymentState;
   /** TRPC API client. Internal use only. */
   trpc: any;
+  /** Custom message to display on confirmation page. */
+  confirmationMessage?: string;
+  setConfirmationMessage: React.Dispatch<
+    React.SetStateAction<string | undefined>
+  >;
 } & useConnectCallbackProps;
 
 /** Meant for internal use. This will be non-exported in a future SDK version. */
@@ -224,6 +229,9 @@ const DaimoPayProviderWithoutSolana = ({
   >();
   const [route, setRoute] = useState<ROUTES>(ROUTES.SELECT_METHOD);
   const [errorMessage, setErrorMessage] = useState<Error>("");
+  const [confirmationMessage, setConfirmationMessage] = useState<
+    string | undefined
+  >(undefined);
 
   const [resize, onResize] = useState<number>(0);
 
@@ -331,6 +339,8 @@ const DaimoPayProviderWithoutSolana = ({
     // Other configuration
     options: opts,
     errorMessage,
+    confirmationMessage,
+    setConfirmationMessage,
     debugMode,
     log,
     displayError: (message: string | React.ReactNode | null, code?: any) => {

--- a/packages/connectkit/src/components/Pages/Confirmation/index.tsx
+++ b/packages/connectkit/src/components/Pages/Confirmation/index.tsx
@@ -1,7 +1,12 @@
 import React from "react";
 import { usePayContext } from "../../DaimoPay";
 
-import { ModalContent, ModalH1, PageContent } from "../../Common/Modal/styles";
+import {
+  ModalBody,
+  ModalContent,
+  ModalH1,
+  PageContent,
+} from "../../Common/Modal/styles";
 
 import {
   assert,
@@ -15,7 +20,7 @@ import styled from "../../../styles/styled";
 import PoweredByFooter from "../../Common/PoweredByFooter";
 
 const Confirmation: React.FC = () => {
-  const { paymentState } = usePayContext();
+  const { paymentState, confirmationMessage } = usePayContext();
   const { daimoPayOrder } = paymentState;
 
   const { done, txURL } = (() => {
@@ -72,11 +77,16 @@ const Confirmation: React.FC = () => {
         {!done ? (
           <ModalH1>Confirming...</ModalH1>
         ) : (
-          <ModalH1>
-            <Link href={txURL} target="_blank" rel="noopener noreferrer">
-              Payment completed
-            </Link>
-          </ModalH1>
+          <>
+            <ModalH1>
+              <Link href={txURL} target="_blank" rel="noopener noreferrer">
+                Payment completed
+              </Link>
+            </ModalH1>
+            {confirmationMessage && (
+              <ModalBody>{confirmationMessage}</ModalBody>
+            )}
+          </>
         )}
 
         <PoweredByFooter />


### PR DESCRIPTION
add two new parameters to `DaimoPayButton`
- defaultOpen (optioanl bool, default false): open the daimo pay modal automatically upon loading
- confirmationMessage (optional string): show a custom message on the confirmation page


https://github.com/user-attachments/assets/37de89e6-2485-4a1b-a573-741641a4f2c5

